### PR TITLE
Longer fetch timeouts to handle connectivity issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Bible Gateway to Markdown Script CHANGELOG
 
+### v1.4.7, 12.8.2023
+- [Fix] Extend request fetch timeouts for slower connections and connectivity issues
+
 ### v1.4.6, 22.1.2023
 - [Fix] Cope with some odd data in verse numbers in LEB and WEB (thanks to report by @CGIII)
 - [Fix] Cope with a change to BG data for single verse lookups


### PR DESCRIPTION
I keep encountering `Net::OpenTimeout` when fetching some books and found extending the timeout resolved the issue for me. Hopefully this is helpful to others. Thanks you for this too! Let me know if you want anything in the PR changed.